### PR TITLE
Fixed Envoys for 1.8 to 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Downloads
 Check the [releases](https://github.com/EnvoysDev/Envoys/releases) page for downloads.
+You will also need the [newest release](https://github.com/rxdn/DependencyManager/releases/) of DependencyManager alongside this!
 
 # Building
 Ensure Gradle 7 or higher is installed and run `gradle fatJar`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
     kotlin("jvm") version "1.5.20"
     java
     id("maven-publish")
-    id("com.github.johnrengelman.shadow") version "7.0.0"
+    id("com.github.johnrengelman.shadow") version "7.1.0"
 }
 
 group = "com.perkelle.dev.envoys"
-version = "5.7.0"
+version = "5.8.0"
 
 sourceSets.main {
     java.srcDirs("src/main/java", "src/main/kotlin")
@@ -37,8 +37,8 @@ repositories {
 dependencies {
     //implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     compileOnly(kotlin("stdlib"))
-    implementation("com.github.Dot-Rar:DependencyManager:1.0.8")
-    implementation("org.bstats:bstats-bukkit:2.2.1")
+    compileOnly("com.github.Dot-Rar:DependencyManager:1.0.8")
+    implementation("org.bstats:bstats-bukkit:3.0.0")
 
     // nexus repos
     implementation("org.codemc.worldguardwrapper:worldguardwrapper:1.1.6-SNAPSHOT")
@@ -51,54 +51,42 @@ dependencies {
     compileOnly("me.clip:placeholderapi:2.8.2")
     compileOnly("com.gmail.filoghost.holographicdisplays:holographicdisplays-api:2.4.0")
 
-    compileOnly("com.github.TechFortress:GriefPrevention:16.7.1") {
+    compileOnly("com.github.TechFortress:GriefPrevention:16.18") {
         exclude("com.sk89q.worldedit", "worldedit-bukkit")
         exclude("com.sk89q", "worldguard")
         exclude("org.bukkit", "bukkit")
     }
     compileOnly("rhino:js:1.7R2")
-    compileOnly("org.json:json:20190722")
-    compileOnly("xyz.xenondevs:particle:1.5.1")
-    compileOnly("me.lucko:commodore:1.7")
+    compileOnly("org.json:json:20220924")
+    compileOnly("xyz.xenondevs:particle:1.7.1")
+    compileOnly("me.lucko:commodore:2.2")
 
     compileOnly("org.apache.httpcomponents:fluent-hc:4.5.13")
     compileOnly("org.apache.commons:commons-math3:3.6.1")
 }
 
 tasks {
-    build {
-        dependsOn(fatJar)
+    shadowJar {
+        exclude("META-INF/**")
+        exclude("proguard_map.txt")
+        exclude("proguard_seeds.txt")
+        exclude("module-info.class")
+        exclude("LICENSE")
+
+        archiveBaseName.set("Envoys")
+
+        relocate("org.codemc.worldguardwrapper", "com.perkelle.dev.envoys.dependencies.org.codemc.worldguardwrapper")
+        relocate("com.github.CodeMC", "com.perkelle.dev.envoys.dependencies.com.github.CodeMC")
+        relocate("org.bstats", "com.perkelle.dev.envoys.dependencies.org.bstats")
+        //relocate("org.intellij.lang.annotations", "com.perkelle.dev.envoys.dependencies.org.intellij.lang.annotations")
+        //relocate("org.jetbrains.annotations", "com.perkelle.dev.envoys.dependencies.org.jetbrains.annotations")
+        //relocate("xyz.xenondevs", "com.perkelle.dev.envoys.dependencies.xyz.xenondevs")
+        relocate("de.tr7zw", "com.perkelle.dev.envoys.dependencies.de.tr7zw")
+        relocate("me.lucko.jarrelocator", "com.perkelle.dev.envoys.dependencies.me.lucko.jarrelocator")
+        //relocate("org.apache.httpcomponents", "com.perkelle.dev.envoys.dependencies.org.apache.httpcomponents")
+        //relocate("commons-codec", "com.perkelle.dev.envoys.dependencies.commons-codec")
+        //relocate("commons-logging", "com.perkelle.dev.envoys.dependencies.commons-logging")
+        relocate("io.papermc", "com.perkelle.dev.envoys.dependencies.io.papermc")
+        //relocate("org.apache.commons.math3", "com.perkelle.dev.envoys.dependencies.org.apache.commons.math3")
     }
-}
-
-val fatJar by tasks.registering(ShadowJar::class) {
-    dependsOn("jar")
-    val jar = tasks.named("jar")
-
-    exclude("META-INF/**")
-    exclude("proguard_map.txt")
-    exclude("proguard_seeds.txt")
-    exclude("module-info.class")
-    exclude("LICENSE")
-
-    configurations = listOf(project.configurations.runtimeClasspath.get())
-    archiveBaseName.set("Envoys")
-
-    //relocate("kotlin", "com.perkelle.dev.envoys.dependencies.kotlin")
-    //relocate("org.jetbrains.kotlin", "com.perkelle.dev.envoys.dependencies.org.jetbrains.kotlin")
-    //relocate("org.json", "com.perkelle.dev.envoys.dependencies.org.json")
-
-    relocate("org.codemc.worldguardwrapper", "com.perkelle.dev.envoys.dependencies.org.codemc.worldguardwrapper")
-    relocate("com.github.CodeMC", "com.perkelle.dev.envoys.dependencies.com.github.CodeMC")
-    relocate("org.bstats", "com.perkelle.dev.envoys.dependencies.org.bstats")
-    //relocate("org.intellij.lang.annotations", "com.perkelle.dev.envoys.dependencies.org.intellij.lang.annotations")
-    //relocate("org.jetbrains.annotations", "com.perkelle.dev.envoys.dependencies.org.jetbrains.annotations")
-    //relocate("xyz.xenondevs", "com.perkelle.dev.envoys.dependencies.xyz.xenondevs")
-    relocate("de.tr7zw", "com.perkelle.dev.envoys.dependencies.de.tr7zw")
-    relocate("me.lucko.jarrelocator", "com.perkelle.dev.envoys.dependencies.me.lucko.jarrelocator")
-    //relocate("org.apache.httpcomponents", "com.perkelle.dev.envoys.dependencies.org.apache.httpcomponents")
-    //relocate("commons-codec", "com.perkelle.dev.envoys.dependencies.commons-codec")
-    //relocate("commons-logging", "com.perkelle.dev.envoys.dependencies.commons-logging")
-    relocate("io.papermc", "com.perkelle.dev.envoys.dependencies.io.papermc")
-    //relocate("org.apache.commons.math3", "com.perkelle.dev.envoys.dependencies.org.apache.commons.math3")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.java.home=/usr/lib/jvm/java-1.16.0-openjdk-amd64

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,9 @@
 name: Envoys
 main: com.perkelle.dev.envoys.Bootstrap
-version: 5.7.0
+version: 5.8.0
 api-version: 1.13
 softdepend: [PlaceholderAPI, WorldEdit, WorldGuard, HolographicDisplays, Multiverse-Core, GriefPrevention]
+depend: [DependencyManager]
 permissions:
   envoys.*:
     description: Gives access to all envoy commands
@@ -28,13 +29,13 @@ permissions:
 
 libraries:
   - org.jetbrains.kotlin:kotlin-stdlib:1.5.20
-  - xyz.xenondevs:particle:1.5.1
+  - xyz.xenondevs:particle:1.7.1
   - rhino:js:1.7R2
-  - org.json:json:20190722
-  - me.lucko:commodore:1.10
-  - commons-codec:commons-codec:1.11
+  - org.json:json:20220924
+  - me.lucko:commodore:2.2
+  - commons-codec:commons-codec:1.15
   - commons-logging:commons-logging:1.2
-  - org.apache.httpcomponents:httpcore:4.4.14
+  - org.apache.httpcomponents:httpcore:4.4.15
   - org.apache.httpcomponents:httpclient:4.5.13
   - org.apache.httpcomponents:fluent-hc:4.5.13
   - org.apache.commons:commons-math3:3.6.1


### PR DESCRIPTION
There is a problem with the implementation of DependencyManager causing completely silent fails on ALL versions; including those that should not use it in the first place.

I also fixed and updated some dependencies (Tested to work on every final major version from 1.8.8 to 1.17.1)

The downside of this is that the user must provide DependencyManager themselves if they are using a Java version below 16 - On 1.16 with old Java this would cause the libraries to be downloaded by both Spigot AND DependencyManager; a minor issue as they can just use Java 16. I would be happy to open a second PR to fix this also.

Thank you for this plugin; hopefully this helps.